### PR TITLE
Make it possible to create ISO/RPI image from any working directory

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -1,6 +1,6 @@
 ## Create an ISO
 ```
-podman run --pull=always --rm -v .:/data:Z -w /data quay.io/routernetes/create-iso:latest
+podman run --pull=always --rm -v .:/data:Z -w /data -e DEST_DEVICE=/dev/sda quay.io/routernetes/create-iso:latest
 ```
 
 A file named ```routernetes.iso``` will be created in your working directory.

--- a/installer/create_iso.sh
+++ b/installer/create_iso.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -e
 
+DEST_DEVICE=${DEST_DEVICE:-/dev/sda}
+
 rm -f routernetes.iso
 coreos-installer download -f iso -C /tmp
 butane --pretty --strict -o /tmp/config.ign /etc/butane.yaml
 coreos-installer iso customize \
-    --dest-device /dev/sda \
+    --dest-device "${DEST_DEVICE}" \
     --dest-ignition /tmp/config.ign \
     -o routernetes.iso /tmp/fedora-coreos-*-live.x86_64.iso

--- a/installer/create_iso.sh
+++ b/installer/create_iso.sh
@@ -3,7 +3,7 @@ set -e
 
 rm -f routernetes.iso
 coreos-installer download -f iso -C /tmp
-butane --pretty --strict -o /tmp/config.ign butane.yaml
+butane --pretty --strict -o /tmp/config.ign /etc/butane.yaml
 coreos-installer iso customize \
     --dest-device /dev/sda \
     --dest-ignition /tmp/config.ign \

--- a/installer/create_rpi_image.sh
+++ b/installer/create_rpi_image.sh
@@ -2,7 +2,7 @@
 set -e
 
 RELEASE=$(curl -sL https://builds.coreos.fedoraproject.org/streams/stable.json | jq -r '.architectures.aarch64.artifacts.metal.release'| cut -d. -f1)
-butane --pretty --strict -o /tmp/config.ign butane.yaml
+butane --pretty --strict -o /tmp/config.ign /etc/butane.yaml
 mkdir -p /tmp/RPi4boot/boot/efi/
 dnf install -y --downloadonly --release=$RELEASE --forcearch=aarch64 --destdir=/tmp/RPi4boot/ uboot-images-armv8 bcm283x-firmware bcm283x-overlays
 

--- a/installer/iso.Containerfile
+++ b/installer/iso.Containerfile
@@ -3,5 +3,6 @@ FROM registry.fedoraproject.org/fedora-minimal:36
 RUN microdnf -y update && microdnf -y install coreos-installer butane && microdnf -y clean all
 
 ADD create_iso.sh /scripts/create_iso.sh
+ADD butane.yaml /etc/butane.yaml
 
 CMD ["/bin/bash", "-c", "/scripts/create_iso.sh"]

--- a/installer/rpi.Containerfile
+++ b/installer/rpi.Containerfile
@@ -3,5 +3,6 @@ FROM registry.fedoraproject.org/fedora:36
 RUN dnf -y update && dnf -y install coreos-installer butane jq curl util-linux cpio rsync && dnf -y clean all
 
 ADD create_rpi_image.sh /scripts/create_rpi_image.sh
+ADD butane.yaml /etc/butane.yaml
 
 CMD ["/bin/bash", "-c", "/scripts/create_rpi_image.sh"]


### PR DESCRIPTION
First of all, routernetes is a cool idea and a really interesting design. Thanks for putting it out!

The podman commands in installer [README](https://github.com/routernetes/routernetes/tree/main/installer#readme) work only when launched with the `routernetes/installer` directory. This is because the create_iso.sh (and create_rpi.sh) script(s) require butane.yaml to be present in the working directory but are not shipped with the container by default.

this PR proposes a change to ship the butane config with the (create-iso) container. This makes the commands work as documented but requires the user to add an option to the podman invocation if they wish to supply a custom butane.yaml. If this approach makes sense, I'd be happy to update the rpi.Containerfile and script as well.

Once again, thanks for creating routernetes and a chance to contribute.